### PR TITLE
Fix type error in some situation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ export function autoRun<T>(
   func: () => void,
   decorator?: (func: () => void) => () => void
 ): {start: () => void; stop: () => void} {
-  let isTrigger: (event: ProxyEvent) => boolean;
+  let isTrigger: (event: ProxyEvent) => boolean = () => true;
   const listener = (event: ProxyEvent) => {
     if (isTrigger(event)) {
       proxy.__emitter__.off('event', listener);


### PR DESCRIPTION
In some sitaution,  `isTrigger` would throw type error.